### PR TITLE
Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+zig-out
+.zig-cache

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pub fn main() !void {
     };
 
     const args = try flagz.parse(Args, allocator);
-    defer flagz.deinit(Args, args, allocator);
+    defer flagz.deinit(args, allocator);
 
     std.debug.print("Name: {s}\n", .{args.name});
     std.debug.print("Count: {}\n", .{args.count});

--- a/build.zig
+++ b/build.zig
@@ -28,4 +28,11 @@ pub fn build(b: *std.Build) void {
 
     const run_step = b.step("run", "Run the example");
     run_step.dependOn(&run_cmd.step);
+
+    // Tests
+    const tests = b.addTest(.{ .root_source_file = b.path("src/test.zig") });
+    // tests.root_module.addImport("flagz", flagz_module);
+    const run_tests = b.addRunArtifact(tests);
+    const test_step = b.step("test", "Run tests");
+    test_step.dependOn(&run_tests.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -31,7 +31,7 @@ pub fn build(b: *std.Build) void {
 
     // Tests
     const tests = b.addTest(.{ .root_source_file = b.path("src/test.zig") });
-    // tests.root_module.addImport("flagz", flagz_module);
+    tests.root_module.addImport("flagz", flagz_module);
     const run_tests = b.addRunArtifact(tests);
     const test_step = b.step("test", "Run tests");
     test_step.dependOn(&run_tests.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,14 @@
-.{ .name = "flagz", .version = "0.0.0", .dependencies = .{}, .paths = .{
-    "src/flagz.zig",
-    "src/test.zig",
-    "build.zig",
-    "build.zig.zon",
-    "README.md",
-} }
+.{
+    .name = .flagz,
+    .version = "0.0.0",
+    // CHANGE in YOUR orig/fork
+    .fingerprint = 0x72d9f91e0e410e48,
+    .dependencies = .{},
+    .paths = .{
+        "src/flagz.zig",
+        "src/test.zig",
+        "build.zig",
+        "build.zig.zon",
+        "README.md",
+    },
+}

--- a/src/example.zig
+++ b/src/example.zig
@@ -14,7 +14,7 @@ pub fn main() !void {
     };
 
     const args = try flagz.parse(Args, allocator);
-    defer flagz.deinit(Args, args, allocator);
+    defer flagz.deinit(args, allocator);
 
     std.debug.print("Name: {s}\n", .{args.name});
     std.debug.print("Count: {}\n", .{args.count});

--- a/src/example.zig
+++ b/src/example.zig
@@ -7,7 +7,7 @@ pub fn main() !void {
     const allocator = gpa.allocator();
 
     const Args = struct {
-        name: []u8,
+        name: []const u8,
         count: usize,
         verbose: bool,
         tag: [8]u8,

--- a/src/flagz.zig
+++ b/src/flagz.zig
@@ -142,8 +142,8 @@ pub fn parse(comptime T: type, allocator: std.mem.Allocator) !T {
     return result;
 }
 
-pub fn deinit(comptime T: type, args: T, allocator: std.mem.Allocator) void {
-    const fields = std.meta.fields(T);
+pub fn deinit(args: anytype, allocator: std.mem.Allocator) void {
+    const fields = std.meta.fields(@TypeOf(args));
     inline for (fields) |field| {
         if (@typeInfo(field.type) == .pointer and (field.type == []u8 or field.type == []const u8)) {
             if (@field(args, field.name).len > 0) {

--- a/src/flagz.zig
+++ b/src/flagz.zig
@@ -38,7 +38,11 @@ pub fn parse(comptime T: type, allocator: std.mem.Allocator) !T {
     while (arg_index < args.len) : (arg_index += 1) {
         const arg = args[arg_index];
         if (arg.len > 1 and arg[0] == '-') {
-            const flag_name = arg[1..];
+            var start_idx: usize = 1;
+            if (arg.len > 2 and arg[1] == '-') {
+                start_idx = 2;
+            }
+            const flag_name = arg[start_idx..];
             inline for (fields) |field| {
                 const field_name = if (field.name[0] == '.')
                     field.name[1..]
@@ -141,7 +145,7 @@ pub fn parse(comptime T: type, allocator: std.mem.Allocator) !T {
 pub fn deinit(comptime T: type, args: T, allocator: std.mem.Allocator) void {
     const fields = std.meta.fields(T);
     inline for (fields) |field| {
-        if (@typeInfo(field.type) == .pointer and field.type == []u8) {
+        if (@typeInfo(field.type) == .pointer and (field.type == []u8 or field.type == []const u8)) {
             if (@field(args, field.name).len > 0) {
                 allocator.free(@field(args, field.name));
             }

--- a/src/flagz.zig
+++ b/src/flagz.zig
@@ -22,12 +22,12 @@ pub fn parse(comptime T: type, allocator: std.mem.Allocator) !T {
 
     inline for (fields) |field| {
         switch (@typeInfo(field.type)) {
-            .Bool => @field(result, field.name) = false,
-            .Int => @field(result, field.name) = 0,
-            .Array => |arr| if (arr.child == u8) {
+            .bool => @field(result, field.name) = false,
+            .int => @field(result, field.name) = 0,
+            .array => |arr| if (arr.child == u8) {
                 @field(result, field.name) = [_]u8{0} ** arr.len;
             },
-            .Pointer => |ptr| if (ptr.child == u8) {
+            .pointer => |ptr| if (ptr.child == u8) {
                 @field(result, field.name) = "";
             },
             else => @compileError("Unsupported field type: " ++
@@ -47,13 +47,13 @@ pub fn parse(comptime T: type, allocator: std.mem.Allocator) !T {
 
                 if (std.mem.eql(u8, flag_name, field_name)) {
                     switch (@typeInfo(field.type)) {
-                        .Bool => {
+                        .bool => {
                             @field(result, field.name) = true;
                         },
-                        .Int => |_| {
+                        .int => |_| {
                             if (arg_index + 1 >= args.len) {
                                 inline for (fields) |f| {
-                                    if (@typeInfo(f.type) == .Pointer and
+                                    if (@typeInfo(f.type) == .pointer and
                                         f.type == []u8 and
                                         @field(result, f.name).len > 0)
                                     {
@@ -66,7 +66,7 @@ pub fn parse(comptime T: type, allocator: std.mem.Allocator) !T {
                             @field(result, field.name) =
                                 std.fmt.parseInt(field.type, value, 10) catch {
                                     inline for (fields) |f| {
-                                        if (@typeInfo(f.type) == .Pointer and
+                                        if (@typeInfo(f.type) == .pointer and
                                             f.type == []u8 and
                                             @field(result, f.name).len > 0)
                                         {
@@ -80,10 +80,10 @@ pub fn parse(comptime T: type, allocator: std.mem.Allocator) !T {
                                 };
                             arg_index += 1;
                         },
-                        .Pointer => |ptr| if (ptr.child == u8) {
+                        .pointer => |ptr| if (ptr.child == u8) {
                             if (arg_index + 1 >= args.len) {
                                 inline for (fields) |f| {
-                                    if (@typeInfo(f.type) == .Pointer and
+                                    if (@typeInfo(f.type) == .pointer and
                                         f.type == []u8 and
                                         @field(result, f.name).len > 0)
                                     {
@@ -97,10 +97,10 @@ pub fn parse(comptime T: type, allocator: std.mem.Allocator) !T {
                             @field(result, field.name) = copied;
                             arg_index += 1;
                         },
-                        .Array => |arr| if (arr.child == u8) {
+                        .array => |arr| if (arr.child == u8) {
                             if (arg_index + 1 >= args.len) {
                                 inline for (fields) |f| {
-                                    if (@typeInfo(f.type) == .Pointer and
+                                    if (@typeInfo(f.type) == .pointer and
                                         f.type == []u8 and
                                         @field(result, f.name).len > 0)
                                     {
@@ -112,7 +112,7 @@ pub fn parse(comptime T: type, allocator: std.mem.Allocator) !T {
                             const value = args[arg_index + 1];
                             if (value.len > arr.len) {
                                 inline for (fields) |f| {
-                                    if (@typeInfo(f.type) == .Pointer and
+                                    if (@typeInfo(f.type) == .pointer and
                                         f.type == []u8 and
                                         @field(result, f.name).len > 0)
                                     {
@@ -141,7 +141,7 @@ pub fn parse(comptime T: type, allocator: std.mem.Allocator) !T {
 pub fn deinit(comptime T: type, args: T, allocator: std.mem.Allocator) void {
     const fields = std.meta.fields(T);
     inline for (fields) |field| {
-        if (@typeInfo(field.type) == .Pointer and field.type == []u8) {
+        if (@typeInfo(field.type) == .pointer and field.type == []u8) {
             if (@field(args, field.name).len > 0) {
                 allocator.free(@field(args, field.name));
             }

--- a/src/test.zig
+++ b/src/test.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const flagz = @import("flagz.zig");
+const flagz = @import("flagz");
 
 test "normal case - all fields set" {
     const Args = struct {

--- a/src/test.zig
+++ b/src/test.zig
@@ -3,7 +3,7 @@ const flagz = @import("flagz.zig");
 
 test "normal case - all fields set" {
     const Args = struct {
-        name: []u8,
+        name: []const u8,
         count: usize,
         verbose: bool,
         tag: [8]u8,
@@ -20,7 +20,7 @@ test "normal case - all fields set" {
             "hello",
             "-count",
             "42",
-            "-verbose",
+            "--verbose",
             "-tag",
             "ziggy",
         };

--- a/src/test.zig
+++ b/src/test.zig
@@ -34,7 +34,7 @@ test "normal case - all fields set" {
     std.os.argv = @constCast(argv);
 
     const args = try flagz.parse(Args, allocator);
-    defer flagz.deinit(Args, args, allocator);
+    defer flagz.deinit(args, allocator);
 
     try std.testing.expectEqualStrings("hello", args.name);
     try std.testing.expectEqual(@as(usize, 42), args.count);
@@ -154,7 +154,7 @@ test "no flags - empty input" {
     std.os.argv = @constCast(argv);
 
     const args = try flagz.parse(Args, allocator);
-    defer flagz.deinit(Args, args, allocator);
+    defer flagz.deinit(args, allocator);
 
     try std.testing.expectEqualStrings("", args.name);
     try std.testing.expectEqual(@as(usize, 0), args.count);
@@ -188,7 +188,7 @@ test "partial flags - some fields set" {
     std.os.argv = @constCast(argv);
 
     const args = try flagz.parse(Args, allocator);
-    defer flagz.deinit(Args, args, allocator);
+    defer flagz.deinit(args, allocator);
 
     try std.testing.expectEqualStrings("hello", args.name);
     try std.testing.expectEqual(@as(usize, 0), args.count);
@@ -226,7 +226,7 @@ test "multiple strings - all freed" {
     std.os.argv = @constCast(argv);
 
     const args = try flagz.parse(Args, allocator);
-    defer flagz.deinit(Args, args, allocator);
+    defer flagz.deinit(args, allocator);
 
     try std.testing.expectEqualStrings("hello", args.name);
     try std.testing.expectEqualStrings("world", args.title);
@@ -258,7 +258,7 @@ test "zero-length strings - empty input" {
     std.os.argv = @constCast(argv);
 
     const args = try flagz.parse(Args, allocator);
-    defer flagz.deinit(Args, args, allocator);
+    defer flagz.deinit(args, allocator);
 
     try std.testing.expectEqualStrings("", args.name);
 }
@@ -293,7 +293,7 @@ test "invalid flag - ignored" {
     std.os.argv = @constCast(argv);
 
     const args = try flagz.parse(Args, allocator);
-    defer flagz.deinit(Args, args, allocator);
+    defer flagz.deinit(args, allocator);
 
     try std.testing.expectEqualStrings("hello", args.name);
     try std.testing.expectEqual(@as(usize, 42), args.count);


### PR DESCRIPTION
1. Migrate to zig 0.14 

Attention: probably need to change the fingerprint upstream!

2. add test step to build.zig
3. add fix for []const u8 slices in freeing
4. add support for `--name` (double dash arg prefix)
5. **Get rid of `T` in flagz.deinit()**

BTW room for improvements: 

- support `--name=shit` style args. 
- support `-v|--verbose` alternatives (not sure how to do that with this approach, would maybe need some "annotation" field?)